### PR TITLE
feat: only load typescript or javascript files for analysis

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "webpack",
     "start": "webpack-dev-server --mode development --open --hot",
-    "dev": "nodemon ./client/Server/server.js",
+    "dev": "nodemon --ignore temp-file-upload/ ./src/Server/server.mjs",
     "both": "concurrently \"cross-env NODE_ENV=development webpack-dev-server --open --hot --progress --color\" \"nodemon --ignore temp-file-upload/ ./src/server/server.mjs\"",
     "style": "npx tailwindcss -i ./src/Client/input.css -o ./src/Client/Styles/output.css --watch"
   },

--- a/src/Client/Components/RepoUpload.tsx
+++ b/src/Client/Components/RepoUpload.tsx
@@ -32,9 +32,14 @@ function RepoUpload({ popupShowing, setPopupShowing, setClickedNodeData, setAnal
     // -------  File Filtering -------- //
     for (let i = 0; i < files.length; i++) {
       const filePath = files[i].webkitRelativePath;
-      if (!filePath.includes('node_modules') && !filePath.includes('.git') && !filePath.includes('.DS_Store')) {
-        formData.append(filePath, files[i], files[i].name);
-        console.log('array: ', filePath.split('/'));
+      const fileExt = filePath.slice(-4).toLowerCase();
+      //only loading typescript or javascript files
+      if (fileExt === '.jsx' || fileExt === '.tsx' || fileExt.slice(1) === '.js' || fileExt.slice(1) === '.ts') {
+        const pathElements = filePath.split('/');
+        //don't upload files in certain directories and don't upload .DS_Store
+        if (!filePath.includes('node_modules') && !filePath.includes('.git') && !filePath.includes('.DS_Store')) {
+          formData.append(filePath, files[i], files[i].name);
+        }
       }
     }
     // ------- Need to refactor fetch to also save the data to AWS S3 -------- //


### PR DESCRIPTION
- Only loading files with the following extensions: .js, .ts, .jsx, .tsx
- Not loading files in node_modules or .git
- Still not loading .DS_Store
- Adjusted 'npm run dev' script in package.json to account for newer directory structure