### PR TITLE
Added clipPath attribute to leaf nodes

### DIFF
--- a/src/Client/Components/D3.jsx
+++ b/src/Client/Components/D3.jsx
@@ -126,18 +126,6 @@ const Pack = (data, options) => { //data and options are props passed down from 
 
   if (sort != null) root.sort(sort);
 
-  // const links = data.children.flatMap(parent => {
-  //   return parent.dependencies.flatMap(dependency => {
-  //     const source = descendants.find(d => d.data.name === parent.name);
-  //     const target = descendants.find(d => d.data.name === dependency.source);
-  //       console.log('source', source, 'target', target)
-  //     if (source && target) {
-  //         return { source, target };
-  //       }
-  //       return null;
-  //   });
-  // }).filter(link => link !== null);
-
   const links = generateLinks(data);
 
   function generateLinks(node) {
@@ -175,32 +163,6 @@ const Pack = (data, options) => { //data and options are props passed down from 
     .attr("text-anchor", "middle"); //more styling 
 
 
-
-//   svg.append("defs").append("marker")
-//     .attr("id", "arrowhead")
-//     .attr("viewBox", "-10 -10 25 25")
-//     .attr("refX", 0)
-//     .attr("refY", 0)
-//     .attr("orient", "auto")
-//     .attr("markerWidth", 5)
-//     .attr("markerHeight", 5)
-//     .append("path")
-//     .attr("d", "M0,5L-10,0L0,-5")
-//     .attr("fill", "#ccc");
-// svg.append("defs")
-//   .append("marker")
-//   .attr("id", "circle-marker")
-//   .attr("markerWidth", 12) // Enlarge the marker width
-//   .attr("markerHeight", 12) // Enlarge the marker height
-//   .attr("refX", 6) // Position the marker at the end of the line
-//   .attr("refY", 6)
-//   .append("circle")
-//   .attr("cx", 6)
-//   .attr("cy", 6)
-//   .attr("r", 3) // Radius of the circle
-//   .style("fill", "yellow") // Color of the circle
-//   .style("filter", "drop-shadow(0 0 5px rgba(255, 255, 0, 0.7))"); // Glow effect
-
   const g = svg.append("g")
   .attr("id", "pack");
 
@@ -228,34 +190,6 @@ g.append("defs")
       console.log (`These are the filtered links from ${hoveredNode}`, result);
       return result;
     };
-
-    // const hoverIn = (event, node) => {
-    //     const filteredLinks = filterLinks(links, node);
-      
-    //     // Select all existing links and remove them
-    //     svg.selectAll(".link").remove();
-      
-    //     // Append new lines for the filtered links with animation
-    //     svg.selectAll(".link")
-    //       .data(filteredLinks)
-    //       .enter()
-    //       .append("line")
-    //       .attr("class", "link")
-    //       .style("stroke", "black") // Set the color of the links to black
-    //       .style("stroke-width", 2) // Set the width of the lines
-    //       .attr("marker-start", "url(#arrowhead)") // Add a circle marker
-
-    //       .attr("x1", d => d.target.x) // Set initial positions to target node
-    //       .attr("y1", d => d.target.y) // Set initial positions to target node
-    //       .attr("x2", d => d.target.x) // Set initial positions to target node
-    //       .attr("y2", d => d.target.y) // Set initial positions to target node
-    //       .transition()
-    //       .duration(1000) // Set the duration of the transition in milliseconds
-    //       .ease(d3.easeLinear)
-    //       .attr("x2", d => d.source.x) // Transition to source node positions
-    //       .attr("y2", d => d.source.y); // Transition to source node positions
-    // };
-    
     
     
   let isDragging = false;
@@ -403,19 +337,19 @@ function dragended(event, d) {
   if (T) node.append("title").text((d, i) => T[i]);
 
   if (L) {
-    // const uid = `O-${Math.random().toString(16).slice(2)}`;
+    const uid = `O-${Math.random().toString(16).slice(2)}`;
 
     const leaf = node.filter(
       (d) => !d.children && d.r > 10 && L[d.index] != null
     );
 
-    // leaf.append("clipPath")
-    //   .attr("id", d => `${uid}-clip-${d.index}`)
-    //   .append("circle")
-    //   .attr("r", d => d.r);
+    leaf.append("clipPath")
+      .attr("id", d => `${uid}-clip-${d.index}`)
+      .append("circle")
+      .attr("r", d => d.r);
 
     leaf.append("text")
-      // .attr("clip-path", d => `url(${new URL(`#${uid}-clip-${d.index}`, location)})`)
+      .attr("clip-path", d => `url(${new URL(`#${uid}-clip-${d.index}`, location)})`)
       .selectAll("tspan")
       .data((d) => `${L[d.index]}`.split(/\n/g))
       .join("tspan")
@@ -443,13 +377,6 @@ function dragended(event, d) {
   //returning the svg without rendering it, this solves the double render issue
   return svg; 
 };
-
-
-
-
-
-
-
 
 
 const D3 = ({ hierarchyData, popupShowing, setPopupShowing, setClickedNodeData }) => {


### PR DESCRIPTION
<!---
☝️ Prefix your PR title with `fix:`, `feat:`, `docs:`, or other according to the Conventional Commits spec:
https://conventionalcommits.org

👉 Please make sure to follow the Contributing guidelines:
https://github.com/oslabs-beta/.github/blob/main/docs/CONTRIBUTING.md
-->

## Linked issue/ticket

<!-- GitHub Issue / Jira Ticket / Asana Ticket -->
https://prti13scratchproj.atlassian.net/browse/OSP-89

## Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
Added clip path attributes to the leaf nodes. Before this the labels in the nodes were overflowing their radius.

## Reproduction steps

<!-- Include step-by-step instructions on how to reproduce and test this ticket. -->

## Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x] I've followed the [Contributing guidelines](https://github.com/oslabs-beta/.github/blob/main/docs/CONTRIBUTING.md)
- [ x] I've titled my PR according to the [Conventional Commits spec](https://conventionalcommits.org)
- [ ] I've added tests that fail without this PR but pass with it
- [ x] I've linted, tested, and commented my code
- [ x] I've updated documentation (if appropriate)
